### PR TITLE
Add support to copy multiple static files under different paths and export files based on node_env setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Destination of static files can be set in plugin configuration. It will override
   }
 ```
 
-## Exporting multiple static files
+4. Different source of static files based on output directory
 
 If you want to export multiple static files, maybe even under different locations you can use the following approach:
 
@@ -82,10 +82,25 @@ If you want to export multiple static files, maybe even under different location
       "staticOutPath": "assets"
     },
     {
-      "staticPath": "config"
+      "staticPath": "config",
+      "staticOutPath": "configurations"
     }
   ]
 ```
+
+5. Specify different files to export based on set node evironment
+   (for the case below you have to set NODE_ENV to production or development)
+
+"staticFiles": [
+{
+"staticPath": "dev/config",
+"env": "development"
+},
+{
+"staticPath": "prod/config",
+"env": "production"
+}
+],
 
 ### Additional example
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,18 @@ If you want to export multiple static files, maybe even under different location
 5. Specify different files to export based on set node evironment
    (for the case below you have to set NODE_ENV to production or development)
 
-"staticFiles": [
-{
-"staticPath": "dev/config",
-"env": "development"
-},
-{
-"staticPath": "prod/config",
-"env": "production"
-}
-],
+```
+  "staticFiles": [
+    {
+      "staticPath": "dev/config",
+      "env": "development"
+    },
+    {
+      "staticPath": "prod/config",
+      "env": "production"
+    }
+  ],
+```
 
 ### Additional example
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ Destination of static files can be set in plugin configuration. It will override
   }
 ```
 
+## Exporting multiple static files
+
+If you want to export multiple static files, maybe even under different locations you can use the following approach:
+
+```
+ "staticFiles": [
+    {
+      "staticPath": "node_modules/web-ui-components/dist/assets",
+      "staticOutPath": "assets"
+    },
+    {
+      "staticPath": "config"
+    }
+  ]
+```
+
 ### Additional example
 
 Check [examples](https://github.com/elwin013/parcel-reporter-static-files-copy/tree/master/examples) directory for

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you want to export multiple static files, maybe even under different location
   ]
 ```
 
-5. Specify different files to export based on set node evironment
+5. Specify different files to export based on set node environment
    (for the case below you have to set NODE_ENV to production or development)
 
 ```

--- a/index.js
+++ b/index.js
@@ -12,12 +12,7 @@ const staticCopyPlugin = new Reporter({
 
       // in case for multiple static files
       if (Array.isArray(configs)) {
-        console.log("is array");
-
         configs.map((config) => {
-          console.log("another one:");
-          console.log(config);
-
           // Get all dist dir from targets, we'll copy static files into them
           let targets = Array.from(
             new Set(
@@ -43,7 +38,6 @@ const staticCopyPlugin = new Reporter({
       } else {
         // for single static file / dir
         let config = Object.assign({}, configs);
-        console.log(config);
         // Get all dist dir from targets, we'll copy static files into them
         let targets = Array.from(
           new Set(

--- a/index.js
+++ b/index.js
@@ -13,38 +13,42 @@ const staticCopyPlugin = new Reporter({
 
       // in case for multiple static files
       if (Array.isArray(configs)) {
-        configs.map((config) => {
-          if (config.env && config.env !== currentEnv) {
-            continue;
-          }
-          // Get all dist dir from targets, we'll copy static files into them
-          let targets = Array.from(
-            new Set(
-              event.bundleGraph
-                .getBundles()
-                .filter((b) => b.target && b.target.distDir)
-                .map((b) => b.target.distDir)
-            )
-          );
+        configs
+          .filter((config) => {
+            if (config.env && config.env !== currentEnv) {
+              return false;
+            }
+            return true;
+          })
+          .map((config) => {
+            // Get all dist dir from targets, we'll copy static files into them
+            let targets = Array.from(
+              new Set(
+                event.bundleGraph
+                  .getBundles()
+                  .filter((b) => b.target && b.target.distDir)
+                  .map((b) => b.target.distDir)
+              )
+            );
 
-          let distPaths = config.distDir ? [config.distDir] : targets;
+            let distPaths = config.distDir ? [config.distDir] : targets;
 
-          if (config.staticOutPath) {
-            distPaths = distPaths.map((p) => path.join(p, config.staticOutPath));
-          }
+            if (config.staticOutPath) {
+              distPaths = distPaths.map((p) => path.join(p, config.staticOutPath));
+            }
 
-          let staticPath = config.staticPath || path.join(options.projectRoot, "static");
+            let staticPath = config.staticPath || path.join(options.projectRoot, "static");
 
-          for (let distPath of distPaths) {
-            copyDir(staticPath, distPath);
-          }
-        });
+            for (let distPath of distPaths) {
+              copyDir(staticPath, distPath);
+            }
+          });
       } else {
         // for single static file / dir
-        if (config.env && config.env !== currentEnv) {
-          continue;
-        }
         let config = Object.assign({}, configs);
+        if (config.env && config.env !== currentEnv) {
+          return;
+        }
         // Get all dist dir from targets, we'll copy static files into them
         let targets = Array.from(
           new Set(

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 
 const PACKAGE_JSON_SECTION = "staticFiles";
+const currentEnv = process.env.NODE_ENV;
 
 const staticCopyPlugin = new Reporter({
   async report({ event, options }) {
@@ -13,6 +14,9 @@ const staticCopyPlugin = new Reporter({
       // in case for multiple static files
       if (Array.isArray(configs)) {
         configs.map((config) => {
+          if (config.env && config.env !== currentEnv) {
+            continue;
+          }
           // Get all dist dir from targets, we'll copy static files into them
           let targets = Array.from(
             new Set(
@@ -37,6 +41,9 @@ const staticCopyPlugin = new Reporter({
         });
       } else {
         // for single static file / dir
+        if (config.env && config.env !== currentEnv) {
+          continue;
+        }
         let config = Object.assign({}, configs);
         // Get all dist dir from targets, we'll copy static files into them
         let targets = Array.from(


### PR DESCRIPTION
Hi, 

first off thanks for the tool for parcel v1 and v2 (used the parcel v1 version a lot).

In this PR i just added the option to use multiple static files which you can specify in the package json  file.
Basically it just uses the normal config just that it is wrapped in an array.

(My first "real" pr ever so i hope i did everything right ^^) 

Example usage in package.json: 
```
  "staticFiles": [
    {
      "staticPath": "some/assets",
      "staticOutPath": "assets"
    },
    {
      "staticPath": "public/i18n",
      "staticOutPath": "/i18n"
    }
  ]
```